### PR TITLE
Switch appropriate protoconvert return types to values instead of pointers

### DIFF
--- a/protoconvert.go
+++ b/protoconvert.go
@@ -123,13 +123,12 @@ func protoToValue(value *pb.Value) (any, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse UUID: %v", err)
 		}
-		return &id, nil
+		return id, nil
 	case *pb.Value_Date:
 		d := time.Unix(int64((time.Duration(v.Date)*24*time.Hour)/time.Second), 0).UTC()
 		return &d, nil
 	case *pb.Value_Time:
-		t := time.Duration(v.Time)
-		return &t, nil
+		return time.Duration(v.Time), nil
 		// TODO: add decimal support
 		// TODO: add UDT support
 		// TODO: add varint support

--- a/protoconvert_test.go
+++ b/protoconvert_test.go
@@ -103,9 +103,9 @@ func TestProtosToValue(t *testing.T) {
 		"foo",
 		[]byte("bar"),
 		net.IPv4(1, 2, 3, 4).To4(),
-		&id,
+		id,
 		&wd,
-		&wt,
+		wt,
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {


### PR DESCRIPTION
`Duration` is an `int64`, so there isn't a performance gain for using a pointer on 64-bit systems. `UUID` is a slice, and it's idiomatic to return those as values.