### PR TITLE
Add Row Scan function

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -17,6 +17,19 @@ type Row struct {
 	values []any
 }
 
+// Scan copies the values from the row into the provided pointers.
+func (r *Row) Scan(dest ...any) error {
+	if len(r.values) != len(dest) {
+		return fmt.Errorf("row has %d values, got %d pointers", len(r.values), len(dest))
+	}
+	for i, v := range r.values {
+		if err := convertAssign(dest[i], v); err != nil {
+			return fmt.Errorf("failed to assign in row %q at index %d: %w", r, i, err)
+		}
+	}
+	return nil
+}
+
 // Values returns the values in the row.
 func (r *Row) Values() []any {
 	return r.values

--- a/rows_test.go
+++ b/rows_test.go
@@ -46,3 +46,30 @@ func TestNewRowsFromResultSet(t *testing.T) {
 		t.Fatalf("newRowsFromResultSet(%q) unexpected difference (-want +got):\n%s", in, diff)
 	}
 }
+
+func TestRow_Scan(t *testing.T) {
+	in := &Row{
+		spec: &colSpec{
+			names: []string{"name", "age"},
+			idxs:  map[string]int{"name": 0, "age": 1},
+		},
+		values: []interface{}{"Alice", int64(30)},
+	}
+
+	var name string
+	var age int64
+	if err := in.Scan(&name, &age); err != nil {
+		t.Errorf("%q.Scan(%T, %T) failed to scan values: %v", in, name, age, err)
+	}
+
+	if name != "Alice" {
+		t.Errorf("%q.Scan(%T, %T) got name %q, want %q", in, name, age, name, "Alice")
+	}
+	if age != 30 {
+		t.Errorf("%q.Scan(%T, %T) got age %d, want %d", in, name, age, age, 30)
+	}
+}
+
+func TestScanToStruct(t *testing.T) {
+
+}


### PR DESCRIPTION
Mirrors: https://pkg.go.dev/database/sql#Row.Scan
Compatible with the `Addr` functionality of: https://github.com/huandu/go-sqlbuilder/blob/20e19b92deccd1463387579b3b7ce31decf781ae/README.md#using-struct-as-a-light-weight-orm

Contains #9
Contains #11
Contains #15 