### PR TITLE
Fix module name.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module astra-go-sdk
+module github.com/datastax-ext/astra-go-sdk
 
 go 1.18
 


### PR DESCRIPTION
Currently seeing this error at https://pkg.go.dev/github.com/datastax-ext/astra-go-sdk:
<img width="993" alt="Screen Shot 2022-07-20 at 2 59 23 PM" src="https://user-images.githubusercontent.com/817672/180061363-e47c34bf-a1c0-41ab-934b-9de004987ab7.png">

I think this will fix it.