### PR TITLE
Handle null database values with string destinations

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -126,6 +126,9 @@ func convertAssign(dest, src any) error {
 			}
 			*d = nil
 			return nil
+		case *string:
+			*d = ""
+			return nil
 		}
 	}
 

--- a/convert_test.go
+++ b/convert_test.go
@@ -93,6 +93,7 @@ func conversionTests() []conversionTest {
 		{s: uint64(123), d: &scanstr, wantstr: "123"},
 		{s: 1.5, d: &scanstr, wantstr: "1.5"},
 		{s: id, d: &scanstr, wantstr: "12345678-1234-5678-1234-567812345678"},
+		{s: nil, d: &scanstr, wantstr: ""},
 
 		// From time.Time:
 		{s: time.Unix(1, 0).UTC(), d: &scanstr, wantstr: "1970-01-01T00:00:01Z"},


### PR DESCRIPTION
The default value for a string in Go is `''`. The built-in Go SQL driver solves this problem with the `sql.NullString` type. Do we want to support this type? Or do we want to just treat `''` as equivilant to null in this SDK?