### PR TITLE
Handle null UUID pointer edge case

### DIFF
--- a/protoconvert.go
+++ b/protoconvert.go
@@ -65,6 +65,9 @@ func valueToProto(value any) (*pb.Value, error) {
 	case net.IP:
 		return &pb.Value{Inner: &pb.Value_Inet{Inet: &pb.Inet{Value: v[:]}}}, nil
 	case *uuid.UUID:
+		if v == nil {
+			return &pb.Value{Inner: &pb.Value_Null_{Null: &pb.Value_Null{}}}, nil
+		}
 		return &pb.Value{Inner: &pb.Value_Uuid{Uuid: &pb.Uuid{Value: v[:]}}}, nil
 	case uuid.UUID:
 		return &pb.Value{Inner: &pb.Value_Uuid{Uuid: &pb.Uuid{Value: v[:]}}}, nil

--- a/protoconvert_test.go
+++ b/protoconvert_test.go
@@ -249,3 +249,15 @@ func TestProtosToValue(t *testing.T) {
 		t.Fatalf("protosToValue(%v) unexpected difference (-want +got):\n%s", in, diff)
 	}
 }
+
+func TestNilUUIDPointer(t *testing.T) {
+	var src *uuid.UUID
+	got, err := valueToProto(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := &pb.Value{Inner: &pb.Value_Null_{Null: &pb.Value_Null{}}}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("valueToProto(%v) unexpected difference (-want +got):\n%s", src, diff)
+	}
+}


### PR DESCRIPTION
Using the `[:]` slice operator on a null pointer creates some very weird effects.