### PR TITLE
Fix null map error

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -242,6 +242,10 @@ func convertAssign(dest, src any) error {
 			dv.SetString(string(v))
 			return nil
 		}
+	case reflect.Map:
+		if src == nil {
+			return nil
+		}
 	}
 
 	return fmt.Errorf("unsupported Scan, storing driver.Value type %T into type %T", src, dest)

--- a/convert_test.go
+++ b/convert_test.go
@@ -43,6 +43,7 @@ type conversionTest struct {
 	wantbool    bool // used if d is of type *bool
 	wanterr     string
 	wantiface   any
+	wantmap     map[string]int
 	wantptr     *int64 // if non-nil, *d's pointed value must be equal to *wantptr
 	wantnil     bool   // if true, *d must be *int64(nil)
 	wantusrdef  userDefined
@@ -65,6 +66,7 @@ var (
 	scanUUID    uuid.UUID
 	scanptr     *int64
 	scaniface   any
+	scanmap     map[string]int
 )
 
 func conversionTests() []conversionTest {
@@ -161,6 +163,10 @@ func conversionTests() []conversionTest {
 		{s: true, d: &scaniface, wantiface: true},
 		{s: nil, d: &scaniface},
 		{s: []byte(nil), d: &scaniface, wantiface: []byte(nil)},
+
+		// Maps
+		{s: map[string]int{"a": 1}, d: &scanmap, wantmap: map[string]int{"a": 1}},
+		{s: nil, d: &scanmap, wantmap: nil},
 
 		// To a user-defined type
 		{s: 1.5, d: new(userDefined), wantusrdef: 1.5},


### PR DESCRIPTION
`protosToMap` returns `nil` for null `map` values and empty maps. Since `nil` is functionally equivilant to an uninitialized map, a no-op is a valid approach for scanning a `nil` source to a `map` destination.

See https://stackoverflow.com/a/43777033/1079543