### PR TITLE
Add secure connect bundle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,24 @@ TODO
 
 ### Testing
 
-To run fast unit tests, run :
+To run fast unit tests:
 ```shell
 go test ./... -run ^Test -test.short
 ```
 
-To run all unit tests, integration tests, and examples, run:
+To run all unit tests, integration tests, and examples:
+
 ```shell
 go test ./...
 ```
 
-These tests rely on [test containers](https://golang.testcontainers.org/), and require a running Docker daemon to work properly.
+These tests rely on [test containers](https://golang.testcontainers.org/), and
+require a running Docker daemon to work properly.
+
+To run all tests online:
+
+```shell
+go test ./... \
+  -test_scb_path=<path/to/secure-connect-bundle.zip> \
+  -test_token=<AstraCS:...>
+```

--- a/bundle.go
+++ b/bundle.go
@@ -1,0 +1,128 @@
+package astra
+
+import (
+	"archive/zip"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+)
+
+const astraURLSuffix = "apps.astra.datastax.com:443"
+
+type bundle struct {
+	tlsConfig *tls.Config
+	host      string
+	port      int
+}
+
+func loadBundleZip(reader *zip.Reader) (*bundle, error) {
+	contents, err := extract(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	config := struct {
+		Host             string `json:"host"`
+		Port             int    `json:"port"`
+		KeyStorePassword string `json:"keyStorePassword"`
+	}{}
+	err = json.Unmarshal(contents["config.json"], &config)
+	if err != nil {
+		return nil, err
+	}
+
+	// rootCAs := x509.NewCertPool()
+	rootCAs, err := createCertPool()
+	if err != nil {
+		return nil, err
+	}
+
+	ok := rootCAs.AppendCertsFromPEM(contents["ca.crt"])
+	if !ok {
+		return nil, fmt.Errorf("the provided CA cert could not be added to the root CA pool")
+	}
+
+	cert, err := tls.X509KeyPair(contents["cert"], contents["key"])
+	if err != nil {
+		return nil, err
+	}
+
+	var astraURI string
+	if strs := strings.Split(config.Host, "."); len(strs) > 1 {
+		astraURI = fmt.Sprintf("%s.%s", strs[0], astraURLSuffix)
+	} else {
+		return nil, fmt.Errorf("invalid host name: %s", config.Host)
+	}
+
+	return &bundle{
+		tlsConfig: &tls.Config{
+			RootCAs:      rootCAs,
+			Certificates: []tls.Certificate{cert},
+			ServerName:   strings.Split(astraURI, ":")[0],
+		},
+		host: astraURI,
+	}, nil
+}
+
+func loadBundleZipFromPath(path string) (*bundle, error) {
+	reader, err := zip.OpenReader(path)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func(reader *zip.ReadCloser) {
+		_ = reader.Close()
+	}(reader)
+
+	return loadBundleZip(&reader.Reader)
+}
+
+func extract(reader *zip.Reader) (map[string][]byte, error) {
+	contents := make(map[string][]byte)
+
+	for _, file := range reader.File {
+		switch file.Name {
+		case "config.json", "cert", "key", "ca.crt":
+			bytes, err := loadBytes(file)
+			if err != nil {
+				return nil, err
+			}
+			contents[file.Name] = bytes
+		}
+	}
+
+	for _, file := range []string{"config.json", "cert", "key", "ca.crt"} {
+		if _, ok := contents[file]; !ok {
+			return nil, fmt.Errorf("bundle missing '%s' file", file)
+		}
+	}
+
+	return contents, nil
+}
+
+func loadBytes(file *zip.File) ([]byte, error) {
+	r, err := file.Open()
+	if err != nil {
+		return nil, err
+	}
+	res, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.Close(); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func createCertPool() (*x509.CertPool, error) {
+	ca, err := x509.SystemCertPool()
+	if err != nil && runtime.GOOS == "windows" {
+		return x509.NewCertPool(), nil
+	}
+	return ca, err
+}

--- a/client_test.go
+++ b/client_test.go
@@ -10,8 +10,24 @@ import (
 func ExampleNewStaticTokenClient() {
 	astraURI := "<ASTRA_CLUSTER_ID>-<ASTRA_REGION>.apps.astra.datastax.com:443"
 	token := "AstraCS:<...>"
-	c, err := NewStaticTokenClient(
-		astraURI, token,
+	c, err := NewStaticTokenClient(token,
+		WithAstraURI(astraURI),
+		WithDefaultKeyspace("example"),
+		// other options
+	)
+	if err != nil {
+		log.Fatalf("failed to initialize client: %v", err)
+	}
+
+	_, err = c.Query(`<some query>`).Exec()
+	if err != nil {
+		log.Fatalf("failed to execute query: %v", err)
+	}
+}
+
+func ExampleNewStaticTokenClient_withSecureConnectBundle() {
+	c, err := NewStaticTokenClient(token,
+		WithSecureConnectBundle("path/to/secure-connect-bundle.zip"),
 		WithDefaultKeyspace("example"),
 		// other options
 	)
@@ -45,7 +61,7 @@ func ExampleNewTableBasedTokenClient() {
 }
 
 func ExampleClient_Query_withOptions() {
-	c, err := NewStaticTokenClient(endpoint, token)
+	c, err := NewStaticTokenClient(token, WithAstraURI(endpoint))
 	if err != nil {
 		log.Fatalf("failed to initialize client: %v", err)
 	}
@@ -68,7 +84,7 @@ func ExampleClient_Query_withOptions() {
 
 func ExampleClient_Query_cast() {
 	c, err := NewStaticTokenClient(
-		endpoint, token,
+		token, WithAstraURI(endpoint),
 		WithDefaultKeyspace("example"),
 	)
 	if err != nil {
@@ -99,7 +115,7 @@ func ExampleClient_Query_cast() {
 
 func ExampleClient_Query_scan() {
 	c, err := NewStaticTokenClient(
-		endpoint, token,
+		token, WithAstraURI(endpoint),
 		WithDefaultKeyspace("example"),
 	)
 	if err != nil {
@@ -137,7 +153,7 @@ func ExampleClient_Query_scan() {
 
 func ExampleClient_Batch() {
 	c, err := NewStaticTokenClient(
-		endpoint, token,
+		token, WithAstraURI(endpoint),
 		WithDefaultKeyspace("example"),
 	)
 	if err != nil {
@@ -169,7 +185,7 @@ func ExampleClient_Batch() {
 }
 
 func ExampleClient_Batch_withOptions() {
-	c, err := NewStaticTokenClient(endpoint, token)
+	c, err := NewStaticTokenClient(token, WithAstraURI(endpoint))
 	if err != nil {
 		log.Fatalf("failed to initialize client: %v", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -2,14 +2,32 @@ package astra
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 var (
-	stc             *TestContainer
-	endpoint, token string
+	stc                         *TestContainer
+	endpoint, token             string
+	testSecureConnectBundlePath = flag.String(
+		"test_scb_path",
+		"",
+		"If set, performs integration tests online using a client configured with the secure connect bundle at the given path. Also requires test_token to be set.",
+	)
+	testToken = flag.String(
+		"test_token",
+		"",
+		"If set, performs integration tests online using a client configured with the given token.",
+	)
+
+	createTestClient = func() (*Client, error) {
+		return stc.CreateClientWithStaticToken()
+	}
 )
 
 func TestMain(m *testing.M) {
@@ -21,32 +39,63 @@ func TestMain(m *testing.M) {
 	}
 
 	var err error
-	stc, err = NewStargateTestContainer()
-	if err != nil {
-		log.Fatalf("failed to start Stargate container: %v", err)
+	if *testSecureConnectBundlePath != "" {
+		if *testToken == "" {
+			log.Fatal("test_token must be set if test_scb_path is set")
+		}
+		token = *testToken
+
+		bundle, err := loadBundleZipFromPath(*testSecureConnectBundlePath)
+		if err != nil {
+			log.Fatalf("failed to load secure connect bundle: %v", err)
+		}
+		endpoint = bundle.host
+
+		createTestClient = func() (*Client, error) {
+			c, err := NewStaticTokenClient(*testToken, WithSecureConnectBundle(*testSecureConnectBundlePath))
+			if err != nil {
+				return nil, fmt.Errorf("failed to initialize client: %w", err)
+			}
+
+			return c, nil
+		}
+	} else {
+		defaultInsecureCredentials = grpc.WithTransportCredentials(insecure.NewCredentials())
+
+		stc, err = NewStargateTestContainer()
+		if err != nil {
+			log.Fatalf("failed to start Stargate container: %v", err)
+		}
+		endpoint = stc.grpcEndpoint
+		token, err = stc.getAuthToken()
+		if err != nil {
+			log.Fatalf("failed to get auth token: %v", err)
+		}
 	}
 
-	endpoint = stc.grpcEndpoint
-	token, err = stc.getAuthToken()
-	if err != nil {
-		log.Fatalf("failed to get auth token: %v", err)
-	}
-
-	c, err := stc.CreateClientWithStaticToken()
+	c, err := createTestClient()
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 
-	_, err = c.Query(`CREATE KEYSPACE IF NOT EXISTS example WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}`).Exec()
-	if err != nil {
-		log.Fatalf("failed to create example keyspace: %v", err)
+	// For online testing, create "example" and "test" keyspaces manually.
+	if stc != nil {
+		_, err = c.Query(`CREATE KEYSPACE IF NOT EXISTS example WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}`).Exec()
+		if err != nil {
+			log.Fatalf("failed to create example keyspace: %v", err)
+		}
+
+		_, err = c.Query(`CREATE KEYSPACE IF NOT EXISTS test WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}`).Exec()
+		if err != nil {
+			log.Fatalf("failed to create test keyspace: %v", err)
+		}
 	}
 
 	_, err = c.Query(`CREATE TABLE IF NOT EXISTS example.users (
 		id uuid PRIMARY KEY,
 		name text,
 		age int
-	)`).Exec()
+	) WITH default_time_to_live = 30`).Exec()
 	if err != nil {
 		log.Fatalf("failed to create example users table: %v", err)
 	}
@@ -56,11 +105,6 @@ func TestMain(m *testing.M) {
 		Exec()
 	if err != nil {
 		log.Fatalf("failed to insert example user Alice: %v", err)
-	}
-
-	_, err = c.Query(`CREATE KEYSPACE IF NOT EXISTS test WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}`).Exec()
-	if err != nil {
-		log.Fatalf("failed to create test keyspace: %v", err)
 	}
 
 	_, err = c.Query(`CREATE TABLE IF NOT EXISTS test.all_types (
@@ -86,7 +130,7 @@ func TestMain(m *testing.M) {
 		list_list_col list<frozen<list<text>>>,
 		set_col set<text>,
 		tuple_col tuple<int, text, float>
-	)`).Exec()
+	) WITH default_time_to_live = 30`).Exec()
 	if err != nil {
 		log.Fatalf("failed to create test table: %v", err)
 	}

--- a/options.go
+++ b/options.go
@@ -45,3 +45,30 @@ func WithTLSConfig(config *tls.Config) ClientOption {
 		c.tlsConfig = config
 	}
 }
+
+// WithInsecure specifies whether to use an insecure connection. Intended
+// localhost testing only.
+func WithInsecure(insecure bool) ClientOption {
+	return func(c *Client) {
+		c.insecure = insecure
+	}
+}
+
+// StaticTokenConnectConfig describes a connection method to use in a call to
+// NewStaticTokenClient.
+type StaticTokenConnectConfig func(*Client)
+
+// WithAstraURI specifies the Astra URI to use for the gRPC connection.
+func WithAstraURI(uri string) StaticTokenConnectConfig {
+	return func(c *Client) {
+		c.astraURI = uri
+	}
+}
+
+// WithSecureConnectBundle specifies the secure connect bundle to use for the
+// gRPC connection.
+func WithSecureConnectBundle(path string) StaticTokenConnectConfig {
+	return func(c *Client) {
+		c.scbPath = path
+	}
+}

--- a/query_test.go
+++ b/query_test.go
@@ -15,7 +15,7 @@ func TestClient_Query_Exec_allTypes(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	c, err := stc.CreateClientWithStaticToken()
+	c, err := createTestClient()
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestClient_Query_Exec_emptyCollections(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	c, err := stc.CreateClientWithStaticToken()
+	c, err := createTestClient()
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/testcontainer.go
+++ b/testcontainer.go
@@ -74,7 +74,7 @@ func (stc *TestContainer) CreateClientWithStaticToken() (*Client, error) {
 		return nil, fmt.Errorf("failed to get auth token: %w", err)
 	}
 
-	c, err := NewStaticTokenClient(stc.grpcEndpoint, token)
+	c, err := NewStaticTokenClient(token, WithAstraURI(stc.grpcEndpoint))
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize client: %w", err)
 	}


### PR DESCRIPTION
- Borrows bundle parsing code from https://github.com/datastax/cql-proxy/blob/bc72398f86e2852d058a3280dc5e33e031b4a76d/astra/bundle.go.
- Refactors `NewStaticTokenClient` constructor to support an endpoint connection with a custom TLS config or a secure connect bundle.
- Adds support for testing with a live Astra backend (much faster than testcontainers).